### PR TITLE
Feat: make grid creation dynamic based on input image count

### DIFF
--- a/visual_scout/extract_frames.py
+++ b/visual_scout/extract_frames.py
@@ -205,7 +205,12 @@ def extract_frames(output_frames_base_path, media_file):
         frame_index = 0
 
         while True:
-            frame_filename = f"frame_00-00-{frame_index}.jpg"
+            # awkward here... trying to force format timestamp format.
+            # May cause errors if there are more than 99 frames in a gif...
+            if frame_index <= 9:
+                frame_index_formatted = f"0{str(frame_index)}"
+    
+            frame_filename = f"frame_00-00-{frame_index_formatted}_00-00-{frame_index_formatted}.jpg"
             frame_path = os.path.join(output_frames_media_path, frame_filename)
             gif.seek(frame_index)
             gif.convert("RGB").save(frame_path)

--- a/visual_scout/generate_grids.py
+++ b/visual_scout/generate_grids.py
@@ -59,41 +59,25 @@ def process_images_in_chunks(files, input_directory, output_directory, grid_dime
     chunk_size = grid_dimension ** 2  # NxN grid = (grid_dimension * grid_dimension) images per grid
     for i in range(0, len(files), chunk_size):
         chunk = files[i:i + chunk_size]
-        print("chunk",chunk)
         images = [Image.open(os.path.join(input_directory, file)) for file in chunk]
-        print("images", images)
 
         frame_width, frame_height = images[0].size
-        print("frame_width, frame_height", frame_width, frame_height)
         grid = create_grid(images, frame_width, frame_height, grid_dimension)
 
         first_file_in_chunk = chunk[0]
         last_file_in_chunk = chunk[-1]
-        print("first_file_in_chunk:", first_file_in_chunk)
-        print("last_file_in_chunk:", last_file_in_chunk)
         first_file_in_chunk_timestamps = extract_timestamps(first_file_in_chunk)
         last_file_in_chunk_timestamps = extract_timestamps(last_file_in_chunk)
-        
-        print("first_file_in_chunk_timestamps", first_file_in_chunk_timestamps )
-        print("last_file_in_chunk_timestamps", last_file_in_chunk_timestamps)
-
 
         start_timestamp = first_file_in_chunk_timestamps[0]
         end_timestamp = last_file_in_chunk_timestamps[-1]
-
-        print("start_timestamp",start_timestamp )
-        print("end_timestamp", end_timestamp)
 
         save_grid(grid, output_directory, start_timestamp, end_timestamp)
 
 def create_grids_from_frames(grid_dimension, input_directory, output_directory):
     """Processes frames from given input location"""
 
-    print(f"input_directory:{input_directory}")
-
     input_videos = os.listdir(input_directory)
-
-    print(f"input_videos: {input_videos}")
     for video_folder in os.listdir(input_directory):
         video_folder_path = os.path.join(input_directory, video_folder)
         if os.path.isdir(video_folder_path):  # Ensure it's a directory

--- a/visual_scout/generate_grids.py
+++ b/visual_scout/generate_grids.py
@@ -1,42 +1,51 @@
 import os
 from PIL import Image
+from math import ceil, sqrt
 from visual_scout.image_utils import extract_timestamps
 from visual_scout.video_utils import get_image_files
 
+
 def create_grid(images, frame_width, frame_height, grid_dimension):
     """
-    Creates a composite grid image from a list of individual images.
+    Create a square grid image from a list of images, ensuring as much space is filled as possible.
 
-    This function arranges a list of images into a square grid format, where 
-    each image is placed at its respective position based on the given 
-    `grid_dimension`. The resulting grid is created with a white background.
+    The grid size dynamically adjusts based on the number of images while staying within 
+    the `grid_dimension` limit. If there are fewer images than `grid_dimension^2`, the grid 
+    will be resized to the closest square size.
 
     Args:
-        images (list): A list of PIL Image objects to be arranged in the grid.
-        frame_width (int): The width of each individual image in pixels.
-        frame_height (int): The height of each individual image in pixels.
-        grid_dimension (int): The number of images per row and column in the grid (NxN).
+        images (list): List of PIL Image objects.
+        frame_width (int): Width of each individual frame in the grid.
+        frame_height (int): Height of each individual frame in the grid.
+        grid_dimension (int): Maximum grid size (NxN).
 
     Returns:
-        PIL.Image.Image: A new image object containing the arranged grid.
-
-    Notes:
-        - The function assumes `images` contains enough images to fill the grid.
-        - If the number of images is less than `grid_dimension^2`, the remaining grid 
-          spaces will remain blank (white background).
-        - Images are placed in row-major order.
+        PIL.Image: A square grid image containing the provided images, arranged left to right, 
+                   top to bottom, with remaining spaces left blank.
     """
+    num_images = len(images)
 
-    grid_width = grid_dimension * frame_width
-    grid_height = grid_dimension * frame_height
-    grid = Image.new("RGB", (grid_width, grid_height), "white")
+    # Handle the case where there are no images
+    if num_images == 0:
+        return Image.new("RGB", (frame_width, frame_height), "white")  # Return 1x1 blank image
 
+    # Compute minimum square grid needed
+    raw_grid_size = ceil(sqrt(num_images))
+    optimal_grid_dim = min(grid_dimension, raw_grid_size)
+
+    # Create a blank (white) grid
+    grid_size = (optimal_grid_dim * frame_width, optimal_grid_dim * frame_height)
+    grid = Image.new("RGB", grid_size, "white")
+
+    # Arrange images in the grid
     for idx, img in enumerate(images):
-        row, col = divmod(idx, grid_dimension)
+        row, col = divmod(idx, optimal_grid_dim)
         x, y = col * frame_width, row * frame_height
         grid.paste(img, (x, y))
 
     return grid
+
+
 
 def save_grid(grid, output_directory, start_timestamp, end_timestamp):
     """Save the grid image with an appropriate filename."""
@@ -50,18 +59,30 @@ def process_images_in_chunks(files, input_directory, output_directory, grid_dime
     chunk_size = grid_dimension ** 2  # NxN grid = (grid_dimension * grid_dimension) images per grid
     for i in range(0, len(files), chunk_size):
         chunk = files[i:i + chunk_size]
+        print("chunk",chunk)
         images = [Image.open(os.path.join(input_directory, file)) for file in chunk]
+        print("images", images)
 
         frame_width, frame_height = images[0].size
+        print("frame_width, frame_height", frame_width, frame_height)
         grid = create_grid(images, frame_width, frame_height, grid_dimension)
 
         first_file_in_chunk = chunk[0]
         last_file_in_chunk = chunk[-1]
+        print("first_file_in_chunk:", first_file_in_chunk)
+        print("last_file_in_chunk:", last_file_in_chunk)
         first_file_in_chunk_timestamps = extract_timestamps(first_file_in_chunk)
         last_file_in_chunk_timestamps = extract_timestamps(last_file_in_chunk)
+        
+        print("first_file_in_chunk_timestamps", first_file_in_chunk_timestamps )
+        print("last_file_in_chunk_timestamps", last_file_in_chunk_timestamps)
+
 
         start_timestamp = first_file_in_chunk_timestamps[0]
         end_timestamp = last_file_in_chunk_timestamps[-1]
+
+        print("start_timestamp",start_timestamp )
+        print("end_timestamp", end_timestamp)
 
         save_grid(grid, output_directory, start_timestamp, end_timestamp)
 


### PR DESCRIPTION
Previous to this PR all grids would be NxN, regardless of input image count. For single images and the tail end of video frames, often there won't be enough images to fill the default grid size. This PR determines grid dimensions based on number of input images in each "chunk". 

### Example behavior where the given grid size is 3x3

- note that when there are less than 5 images, the grid is 2x2 and when there is only one image the grid is 1x1 (AKA just the input image):

| # Images | Computed Grid Size |
|---|---|
| 1|1x1  |
| 2|2x2 |
| 3| 2x2 |
| 4| 2x2|
| 5| 3x3|
| 6| 3x3|
| 7| 3x3|
| 8| 3x3|
| 9| 3x3|


