### PR TITLE
Chore: update docs, fix dupe numpy install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,96 @@
 
 A work-in-progress tool for extracting visual elements (objects and text) from a set of videos, using OpenAI.
 
+## Requirements
+
+Before installing `visual-scout`, ensure your system has:
+
+1. **python 3.8 or higher**
+
+- To check this run the following and ensure a valid python version is shown: 
+
+```
+python3 --version
+```
+
+2. **FFmpeg and FFprobe**: 
+
+- These command-line tools are required for:
+    - Extracting frames from videos (ffmpeg)
+    - Inspecting video metadata like duration (ffprobe)
+
+- Install on MacOS (using Homebrew):
+
+```
+brew install ffmpeg
+```
+
+- Install on Ubuntu/Debian
+
+```
+sudo apt update
+sudo apt install ffmpeg
+```
+
+## Install with `pipx` (recommended)
+
+_Note:_ pipx is a tool for installing and running Python applications in isolated environments. It ensures that each CLI tool has its own clean environment, separate from your global Python packages. Once installed with pipx, you can run the CLI from anywhere on your computer, just like a native system command.
+
+1. Make sure you have `pipx` installed.
+
+- Option 1: Basic install:
+
+```
+python3 -m pip install --user pipx
+```
+
+Confirm install and add the installed scripts to your shell's PATH:
+
+```
+python3 -m pipx ensurepath
+```
+
+- Option 2: Install with Homebrew: 
+
+```
+brew install pipx
+```
+
+Confirm install and add the installed scripts to your shell's PATH:
+
+```
+pipx ensurepath
+```
+
+2. Open a new terminal windwo to ensure the changes take effect.
+
+3. Install `visual-scout` using pipx:
+
+- This command will:
+    - Clone the Visual Scout repository from GitHub
+    - Install it into an isolated virtual environment
+    - Make the visual-scout command available globally on your system
+
+Option 1: Basic install
+
+```
+python3 -m pipx install git+https://github.com/paigemoody/visual-scout.git
+```
+
+Option 2: Use Homebrew
+
+```
+pipx install git+https://github.com/paigemoody/visual-scout.git
+```
+
+_Note: Eventually, Visual Scout will be published to PyPI._
+
+5. Verify installation
+
+```
+visual-scout --help
+```
+
 ## Development Setup
 
 1. Create virtual environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "MIT" }
 dependencies = [
-    "numpy",
     "dotenv",
     "numpy==1.24.4",
     "opencv-python==4.10.0.84",

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,9 @@
 from setuptools import setup, find_packages
 
-# Read dependencies from requirements.txt
-## TODO break out dev and package requirements
-def read_requirements():
-    with open("requirements.txt", encoding="utf-8") as f:
-        return [line.strip() for line in f if line.strip() and not line.startswith("#")]
-
 setup(
     name="visual-scout",
     version="0.1.0",
     packages=find_packages(),
-    # install_requires=read_requirements(),  # Load requirements from file
     entry_points={
         "console_scripts": [
             "visual-scout=visual_scout.cli:main",


### PR DESCRIPTION
This PR:

- updates docs
- attempts to fix numpy issue, which blocks pipx install

Details on numpy issue:

When installing via pipx, the build process tries to compile numpy from source (rather than using a prebuilt wheel), and that often fails unless:
- You have a C compiler and full Python headers installed
- The exact numpy version you specify has prebuilt wheels for your platform + Python version